### PR TITLE
Adding clearly server for backend on docker-compose dev

### DIFF
--- a/clearly-server/Dockerfile
+++ b/clearly-server/Dockerfile
@@ -1,0 +1,14 @@
+FROM rsalmei/clearly:0 AS patch-image
+
+RUN apt-get update && apt-get upgrade -y
+
+# --------------------------------------------------------------------
+
+FROM patch-image
+
+LABEL maintainer="Nicholas Elia <me@nichelia.com>"
+
+ENV USER="nobody"
+WORKDIR "/tmp"
+
+USER ${USER}

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -12,8 +12,11 @@ services:
       - ./diagram-service/bin:/tmp/bin
   
   clearly-server:
-    image: rsalmei/clearly
-    command: server redis://host.docker.internal:6379/2
+    build:
+      context: clearly-server
+      dockerfile: Dockerfile
+    image: clearly-server
+    command: server "${BROKER_URI}"
     networks:
       - celino
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -10,6 +10,12 @@ services:
     volumes:
       - ./diagram-service/generate_diagrams.py:/tmp/input.py
       - ./diagram-service/bin:/tmp/bin
+  
+  clearly-server:
+    image: rsalmei/clearly
+    command: server redis://host.docker.internal:6379/2
+    networks:
+      - celino
 
 networks:
   celino:


### PR DESCRIPTION
Closes #4 

Adding more services to our `docker-compose` dev.
To make this work:
`export BROKER_URI=<value>`
`docker-compose -f docker-compose.dev.yml build`
`docker-compose -f docker-compose.dev.yml up`

In my scenario, I have a K8s deployment with Redis server. To connect to that server I execute the below on my Mac:
(kubectl is required)
`kubectl port-forward --address='0.0.0.0' service/<redis-service-name> 6379:6379 -n <namespace>`
The above will make a service within a namespace available on your machine, on port `6379`. Because this would be available on my local Mac machine (may differs for Windows, Linux), I need to pass the following as the `BROKER_URI` value: `redis://host.docker.internal:6379`